### PR TITLE
Apply Apple Garamond styling with red background

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,15 +1,11 @@
-:root{
-  --brand-red: #CB1F1F;   /* <-- dein gewünschtes Rot */
-  --text-white: #FFFFFF;
+@import url('https://fonts.cdnfonts.com/css/apple-garamond');
+
+:root {
+  --brand-red: #CB1F1F;   /* Red background */
+  --text-white: #FFFFFF;  /* White text */
   --muted-white: rgba(255,255,255,0.88);
   --panel-alpha: rgba(255,255,255,0.08);
   --card-width: 420px;
-}
-
-@font-face {
-  font-family: "AppleGaramond";
-  src: url("/fonts/AppleGaramond.woff2") format("woff2");
-  font-display: swap;
 }
 
 * { box-sizing: border-box; }
@@ -23,7 +19,7 @@ body {
   padding: 0;
   background: var(--brand-red);     /* red background */
   color: var(--text-white);         /* white text */
-  font-family: "AppleGaramond", Georgia, serif;
+  font-family: "Apple Garamond", Georgia, serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   display: flex;


### PR DESCRIPTION
## Summary
- Load global stylesheet and apply Apple Garamond site-wide
- Import Apple Garamond webfont and use red `#CB1F1F` background with white text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b878e415788332baa0aa031aa99d06