### PR TITLE
Use back.png for card backside and label vinyl chart

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -35,19 +35,26 @@ export default function Card({ personality, artists = [], features = {}, overrid
           : URL.createObjectURL(overrides.back)
       );
     } else {
-      setBackUrl(backPathFor(personality));
+      setBackUrl(backPathFor());
     }
   }, [personality, overrides]);
 
   const download = async () => {
     if (!cardRef.current) return;
+    const wasBack = showBack;
     try {
-      // export only the card image
+      setShowBack(true);
+      await new Promise((r) => setTimeout(r, 100));
       const dataUrl = await toPng(cardRef.current, { cacheBust: true });
-      saveAs(dataUrl, `${(personality || "card").replace(/\s+/g, "-")}.png`);
+      saveAs(
+        dataUrl,
+        `${(personality || "card").replace(/\s+/g, "-")}-back.png`
+      );
     } catch (e) {
       console.error(e);
       alert("Export failed");
+    } finally {
+      setShowBack(wasBack);
     }
   };
 

--- a/components/CdViz.jsx
+++ b/components/CdViz.jsx
@@ -20,6 +20,11 @@ export default function CdViz({ features = {}, size = 300 }) {
       .innerRadius(radiusInner)
       .outerRadius((d) => radiusInner + (d.data[1] / 100) * (radiusOuter - radiusInner));
 
+    const labelArc = d3
+      .arc()
+      .innerRadius(radiusOuter + 12)
+      .outerRadius(radiusOuter + 12);
+
     const color = d3.scaleOrdinal(d3.schemeTableau10);
 
     g.selectAll("path")
@@ -30,6 +35,15 @@ export default function CdViz({ features = {}, size = 300 }) {
       .attr("fill", (d, i) => color(i))
       .attr("stroke", "#fff")
       .attr("stroke-width", 1);
+
+    g.selectAll("text.label")
+      .data(pie)
+      .enter()
+      .append("text")
+      .attr("transform", (d) => `translate(${labelArc.centroid(d)})`)
+      .attr("text-anchor", "middle")
+      .style("font-size", 10)
+      .text((d) => `${d.data[0]} ${d.data[1]}%`);
 
     g.append("circle").attr("r", radiusInner * 0.55).attr("fill", "#fff");
     g.append("text")

--- a/utils/assets.js
+++ b/utils/assets.js
@@ -11,8 +11,6 @@ export function frontPathFor(personality) {
   return `/cards/fronts/${key}.png`;
 }
 
-export function backPathFor(personality) {
-  if (!personality) return "/cards/backs/back.png";
-  const key = NORMALIZE(personality);
-  return `/cards/backs/${key}-back.png`;
+export function backPathFor() {
+  return "/cards/backs/back.png";
 }


### PR DESCRIPTION
## Summary
- always load `back.png` for card reverse
- download exports backside with vinyl chart
- vinyl chart shows feature labels and percentages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6d66758833299ea80982ffb443b