### PR TITLE
Map personalities to card fronts

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -77,7 +77,7 @@ export default function Card({ personality, artists = [], features = {}, overrid
               style={{ width: "100%", display: "block" }}
               onLoad={(e) => setCardHeight(e.currentTarget.offsetHeight)}
               onError={(e) => {
-                e.currentTarget.src = "/cards/fronts/default-front.png";
+                e.currentTarget.src = frontPathFor();
               }}
             />
           </div>
@@ -87,7 +87,7 @@ export default function Card({ personality, artists = [], features = {}, overrid
               alt="back"
               style={{ width: "100%", display: "block" }}
               onError={(e) => {
-                e.currentTarget.src = "/cards/backs/back.png";
+                e.currentTarget.src = backPathFor();
               }}
             />
             <div

--- a/utils/assets.js
+++ b/utils/assets.js
@@ -1,3 +1,6 @@
+import { PERSONALITIES } from "./mapping";
+
+// normalize any string to the matching asset file name
 const NORMALIZE = (s) =>
   (s || "")
     .toLowerCase()
@@ -5,10 +8,17 @@ const NORMALIZE = (s) =>
     .trim()
     .replace(/\s+/g, "-");
 
+// build a lookup map for all 16 personality fronts
+const FRONT_MAP = PERSONALITIES.reduce((acc, name) => {
+  const key = NORMALIZE(name);
+  acc[key] = `/cards/fronts/${key}.png`;
+  return acc;
+}, {});
+
 export function frontPathFor(personality) {
   if (!personality) return "/cards/fronts/default-front.png";
   const key = NORMALIZE(personality);
-  return `/cards/fronts/${key}.png`;
+  return FRONT_MAP[key] || "/cards/fronts/default-front.png";
 }
 
 export function backPathFor() {


### PR DESCRIPTION
## Summary
- build a lookup table for 16 personality card fronts
- keep consistent back card image utility
- route card image fallbacks through asset helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8a686fc8332967f570278b26574