### PR TITLE
Display last month's top songs under card

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -3,7 +3,7 @@ import { toPng } from "html-to-image";
 import { saveAs } from "file-saver";
 import { frontPathFor, backPathFor } from "../utils/assets";
 
-export default function Card({ personality, artists = [], overrides = {} }) {
+export default function Card({ personality, tracks = [], overrides = {} }) {
   // reference the card for PNG export
   const cardRef = useRef();
   const [frontUrl, setFrontUrl] = useState(null);
@@ -90,9 +90,19 @@ export default function Card({ personality, artists = [], overrides = {} }) {
 
       <div style={{ width: 420, margin: "12px auto 0", textAlign: "center" }}>
         <h3 style={{ margin: 0 }}>{personality}</h3>
-        <p style={{ marginTop: 8, color: "#333", fontSize: 14 }}>
-          {artists?.slice(0, 3).map((a) => a.name).join(", ")}
-        </p>
+        <ol
+          style={{
+            marginTop: 8,
+            color: "#fff",
+            fontSize: 14,
+            paddingLeft: 20,
+            textAlign: "left",
+          }}
+        >
+          {tracks?.slice(0, 5).map((t, i) => (
+            <li key={t.id || i}>{t.name}</li>
+          ))}
+        </ol>
       </div>
 
       <div

--- a/pages/app.jsx
+++ b/pages/app.jsx
@@ -16,6 +16,7 @@ const FEATURE_KEYS = [
 export default function AppPage() {
   const [token, setToken] = useState(null);
   const [artists, setArtists] = useState([]);
+  const [tracks, setTracks] = useState([]);
   const [personality, setPersonality] = useState(null);
   const [features, setFeatures] = useState({});
 
@@ -35,6 +36,7 @@ export default function AppPage() {
         const a = await fetchTopArtists(token, 20);
         const t = await fetchTopTracks(token, 20);
         setArtists(a);
+        setTracks(t);
         setPersonality(mapToPersonality(a, t));
         const feat = FEATURE_KEYS.reduce((acc, k) => ({ ...acc, [k]: 0 }), {});
         let count = 0;
@@ -62,7 +64,12 @@ export default function AppPage() {
   return (
     <main className="main-container" style={{ color: "var(--text-white)" }}>
       <div className="card-wrapper">
-        <Card personality={personality} artists={artists} features={features} />
+        <Card
+          personality={personality}
+          tracks={tracks}
+          artists={artists}
+          features={features}
+        />
       </div>
     </main>
   );

--- a/utils/spotify.js
+++ b/utils/spotify.js
@@ -15,10 +15,18 @@ export async function fetchTopArtists(token, limit = 20) {
 }
 
 export async function fetchTopTracks(token, limit = 20) {
-  const res = await axios.get(`https://api.spotify.com/v1/me/top/tracks?limit=${limit}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const tracks = res.data.items.map((t) => ({ id: t.id, name: t.name, artists: t.artists.map(a=>a.name), popularity: t.popularity }));
+  const res = await axios.get(
+    `https://api.spotify.com/v1/me/top/tracks?time_range=short_term&limit=${limit}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  const tracks = res.data.items.map((t) => ({
+    id: t.id,
+    name: t.name,
+    artists: t.artists.map((a) => a.name),
+    popularity: t.popularity,
+  }));
   const ids = tracks.map(t=>t.id).filter(Boolean).join(",");
   if (!ids) return tracks;
   const featRes = await axios.get(`https://api.spotify.com/v1/audio-features?ids=${ids}`, {


### PR DESCRIPTION
## Summary
- Show personality name and list of top tracks beneath the card in white text
- Load user's short-term top tracks and pass them to the card component
- Query Spotify for last month's top tracks via `time_range=short_term`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c31a23e08332bb0fdafac356d620