### PR TITLE
Fix card back image, show artists, and add home logo

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -92,6 +92,7 @@ export default function Card({ personality, tracks = [], overrides = {} }) {
                 display: "block",
                 borderRadius: 12,
                 backfaceVisibility: "hidden",
+                transform: "rotateY(180deg)",
               }}
               onError={(e) => {
                 e.currentTarget.src = backPathFor();
@@ -113,9 +114,14 @@ export default function Card({ personality, tracks = [], overrides = {} }) {
             listStylePosition: "inside",
           }}
         >
-          {tracks?.slice(0, 5).map((t, i) => (
-            <li key={t.id || i}>{t.name}</li>
-          ))}
+          {tracks?.slice(0, 5).map((t, i) => {
+            const artistStr = t.artists?.join(", ");
+            return (
+              <li key={t.id || i}>
+                {artistStr ? `${t.name} by ${artistStr}` : t.name}
+              </li>
+            );
+          })}
         </ol>
       </div>
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -12,10 +12,11 @@ export default function Home() {
 
   return (
     <main className="main-container">
+      <img src="/logo/logo.png" alt="Talking Sound logo" className="logo" />
       <h1> Welcome to Talking Sound! </h1>
       <p>
         Log in with your Spotify & turn your top tracks into your collectible card — front is all about vibes, back is an interactive vinyl of your stats.
-        Have fun, share your card with friends and don't forget to put on your best playlist meanwhile 🌞 
+        Have fun, share your card with friends and don't forget to put on your best playlist meanwhile 🌞
       </p>
 
       <div className="auth-box" aria-hidden={false}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,6 +59,13 @@ body {
   margin-right: auto;
 }
 
+.logo {
+  display: block;
+  margin: 0 auto 24px;
+  max-width: 200px;
+  height: auto;
+}
+
 /* Kasten um Login-Button */
 .auth-box {
   display: inline-block;
@@ -137,4 +144,4 @@ body {
   top: 0;
   left: 0;
 }
-.flip-card-back { transform: rotateY(180deg); }
+.flip-card-back {}


### PR DESCRIPTION
## Summary
- Include artist names alongside track titles in top songs list
- Ensure card back displays dedicated back.png instead of mirrored front
- Add centered logo on the home page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8d2085ee88332a01896cf4635aa74