### PR TITLE
Add privacy and contact pages

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,5 +1,6 @@
 // pages/index.jsx
 import React from "react";
+import Link from "next/link";
 
 const SCOPES = ["user-top-read"].join(" ");
 const CLIENT_ID = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
@@ -25,6 +26,9 @@ export default function Home() {
           Login with Spotify
         </a>
       </div>
+      <nav className="page-links">
+        <Link href="/privacy">Data Privacy</Link> | <Link href="/kontakt">Kontakt</Link>
+      </nav>
     </main>
   );
 }

--- a/pages/kontakt.jsx
+++ b/pages/kontakt.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function KontaktPage() {
+  return (
+    <main className="main-container contact">
+      <h1>Contact</h1>
+      <p>
+        You can reach me at <a href="mailto:alina.weidemann04@gmail.com">alina.weidemann04@gmail.com</a>.
+      </p>
+      <p>
+        Connect with me on{" "}
+        <a href="https://www.linkedin.com/in/alina-weidemann" target="_blank" rel="noopener noreferrer">LinkedIn</a>.
+      </p>
+    </main>
+  );
+}

--- a/pages/privacy.jsx
+++ b/pages/privacy.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function PrivacyPage() {
+  return (
+    <main className="main-container">
+      <h1>Data Privacy</h1>
+      <p>
+        This site uses your Spotify information only to generate your personal music card.
+        No listening data or personal details are stored on our servers.
+      </p>
+      <p>
+        The data retrieved during your session is processed solely in your browser and discarded
+        immediately after use.
+      </p>
+    </main>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -146,3 +146,20 @@ body {
   left: 0;
 }
 .flip-card-back {}
+
+/* Navigation links on the home page */
+.page-links {
+  margin-top: 24px;
+}
+
+.page-links a {
+  color: var(--muted-white);
+  margin: 0 8px;
+  text-decoration: underline;
+}
+
+/* Contact page link styling */
+.contact a {
+  color: var(--brand-red);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add Data Privacy page to explain that no user data is stored
- add Kontakt page with email address and LinkedIn link
- link new pages from the homepage with basic styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8db7fbff48332aa1948730f9becfe