### PR TITLE
feat: add analytic charts to card back

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -2,8 +2,9 @@ import React, { useRef, useState, useEffect } from "react";
 import { toPng } from "html-to-image";
 import { saveAs } from "file-saver";
 import { frontPathFor, backPathFor } from "../utils/assets";
+import VinylChart from "./VinylChart";
 
-export default function Card({ personality, tracks = [], overrides = {} }) {
+export default function Card({ personality, tracks = [], artists = [], overrides = {} }) {
   // reference each card face for PNG export
   const frontRef = useRef();
   const backRef = useRef();
@@ -69,15 +70,20 @@ export default function Card({ personality, tracks = [], overrides = {} }) {
             e.currentTarget.src = frontPathFor();
           }}
         />
-        <img
+        <div
           ref={backRef}
-          src={backUrl}
-          alt="back"
-          style={{ width: 420, display: "block", borderRadius: 12 }}
-          onError={(e) => {
-            e.currentTarget.src = backPathFor();
-          }}
-        />
+          style={{ position: "relative", width: 420, borderRadius: 12, overflow: "hidden" }}
+        >
+          <img
+            src={backUrl}
+            alt="back"
+            style={{ width: 420, display: "block" }}
+            onError={(e) => {
+              e.currentTarget.src = backPathFor();
+            }}
+          />
+          <VinylChart artistData={artists} trackData={tracks} />
+        </div>
       </div>
 
       <div style={{ width: 840, margin: "12px auto 0", textAlign: "center" }}>

--- a/components/VinylChart.jsx
+++ b/components/VinylChart.jsx
@@ -2,37 +2,32 @@ import React, { useEffect, useRef } from "react";
 
 export default function VinylChart({ artistData = [], trackData = [] }) {
   const containerRef = useRef(null);
+  const audioRef = useRef(null);
 
   useEffect(() => {
     let svg;
     let tooltip;
-    let audio;
-    let cancelled = false;
 
     import("d3").then((d3) => {
-      if (cancelled) return;
-      const width = 300;
-      const height = 300;
       const root = containerRef.current;
       if (!root) return;
+      const width = root.clientWidth || 300;
+      const height = root.clientHeight || 300;
+      const size = Math.min(width, height, 300);
+      const leftOffset = (width - size) / 2;
+      const topOffset = (height - size) / 2;
+      const radius = size / 2;
 
       svg = d3
         .select(root)
         .append("svg")
-        .attr("width", width)
-        .attr("height", height);
+        .attr("width", size)
+        .attr("height", size)
+        .style("position", "absolute")
+        .style("left", leftOffset + "px")
+        .style("top", topOffset + "px");
 
-      const g = svg
-        .append("g")
-        .attr("transform", `translate(${width / 2},${height / 2})`);
-
-      const radii = d3.range(5).map((i) => width / 2 - i * 25);
-      g.selectAll("circle")
-        .data(radii)
-        .enter()
-        .append("circle")
-        .attr("r", (d) => d)
-        .attr("fill", (_, i) => (i % 2 ? "#222" : "#111"));
+      const g = svg.append("g").attr("transform", `translate(${radius},${radius})`);
 
       tooltip = d3
         .select(root)
@@ -46,29 +41,107 @@ export default function VinylChart({ artistData = [], trackData = [] }) {
         .style("border-radius", "4px")
         .style("opacity", 0);
 
-      svg
-        .on("mousemove", (event) => {
+      // Artist-Share Arcs (Outer Ring)
+      const artists = artistData.slice(0, 6);
+      const weights = artists.map((a) => a.followers || a.popularity || 1);
+      const pie = d3.pie()(weights);
+      const arc = d3.arc().innerRadius(radius - 20).outerRadius(radius);
+      const color = d3.scaleOrdinal(d3.schemeCategory10);
+
+      g.selectAll("path.artist-arc")
+        .data(pie)
+        .enter()
+        .append("path")
+        .attr("class", "artist-arc")
+        .attr("d", arc)
+        .attr("fill", (d, i) => color(i))
+        .on("mousemove", (event, d) => {
+          const artist = artists[d.index];
           tooltip
             .style("left", event.offsetX + 10 + "px")
             .style("top", event.offsetY + 10 + "px")
             .style("opacity", 1)
-            .text(trackData[0]?.name || "Vinyl");
+            .text(artist.name);
         })
-        .on("mouseleave", () => tooltip.style("opacity", 0));
+        .on("mouseleave", () => tooltip.style("opacity", 0))
+        .on("click", (_, d) => {
+          const artist = artists[d.index];
+          if (artist?.id) {
+            window.open(`https://open.spotify.com/artist/${artist.id}`, "_blank");
+          }
+        });
 
-      if (trackData[0]?.preview_url) {
-        audio = new Audio(trackData[0].preview_url);
-        audio.loop = true;
-        audio.play().catch(() => {});
-      }
+      // Danceability Wave (Mid Ring)
+      const barBase = radius - 40;
+      const lengthScale = d3.scaleLinear().domain([0, 1]).range([0, 40]);
+      const angle = (i) => (i / trackData.length) * 2 * Math.PI;
+
+      g.selectAll("line.dance-bar")
+        .data(trackData)
+        .enter()
+        .append("line")
+        .attr("class", "dance-bar")
+        .attr("x1", (d, i) => barBase * Math.cos(angle(i)))
+        .attr("y1", (d, i) => barBase * Math.sin(angle(i)))
+        .attr(
+          "x2",
+          (d, i) =>
+            (barBase + lengthScale(d.audio_features?.danceability || 0)) * Math.cos(angle(i))
+        )
+        .attr(
+          "y2",
+          (d, i) =>
+            (barBase + lengthScale(d.audio_features?.danceability || 0)) * Math.sin(angle(i))
+        )
+        .attr("stroke", "#ff7f00")
+        .attr("stroke-width", 2);
+
+      // Valence × Energy Scatter (Inner Emotional Map)
+      const scatterRadius = barBase - 10;
+      const valToAngle = d3.scaleLinear().domain([0, 1]).range([0, 2 * Math.PI]);
+      const energyToR = d3.scaleLinear().domain([0, 1]).range([0, scatterRadius]);
+      const valColor = d3.scaleSequential(d3.interpolateTurbo).domain([0, 1]);
+
+      g.selectAll("circle.track-dot")
+        .data(trackData)
+        .enter()
+        .append("circle")
+        .attr("class", "track-dot")
+        .attr("cx", (d) => {
+          const a = valToAngle(d.audio_features?.valence || 0);
+          return energyToR(d.audio_features?.energy || 0) * Math.cos(a);
+        })
+        .attr("cy", (d) => {
+          const a = valToAngle(d.audio_features?.valence || 0);
+          return energyToR(d.audio_features?.energy || 0) * Math.sin(a);
+        })
+        .attr("r", (d) => 3 + (d.popularity || 0) / 40)
+        .attr("fill", (d) => valColor(d.audio_features?.valence || 0))
+        .on("mousemove", (event, d) => {
+          tooltip
+            .style("left", event.offsetX + 10 + "px")
+            .style("top", event.offsetY + 10 + "px")
+            .style("opacity", 1)
+            .text(d.name);
+        })
+        .on("mouseleave", () => tooltip.style("opacity", 0))
+        .on("click", (_, d) => {
+          if (audioRef.current) {
+            audioRef.current.pause();
+            audioRef.current = null;
+          }
+          if (d.preview_url) {
+            const a = new Audio(d.preview_url);
+            audioRef.current = a;
+            a.play().catch(() => {});
+          }
+        });
     });
 
     return () => {
-      cancelled = true;
-      if (audio) {
-        audio.pause();
-        audio.src = "";
-        audio = null;
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
       }
       if (tooltip) tooltip.remove();
       if (svg) svg.remove();

--- a/utils/spotify.js
+++ b/utils/spotify.js
@@ -26,6 +26,7 @@ export async function fetchTopTracks(token, limit = 20) {
     name: t.name,
     artists: t.artists.map((a) => a.name),
     popularity: t.popularity,
+    preview_url: t.preview_url,
   }));
   const ids = tracks.map(t=>t.id).filter(Boolean).join(",");
   if (!ids) return tracks;


### PR DESCRIPTION
## Summary
- overlay custom vinyl-style chart on card back with artist share arcs, valence/energy scatter, and danceability wave
- wire card component to render chart and supply artist/track data
- expose track preview URLs for audio previews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8e7848c648332933c907867c25be7