### PR TITLE
Use brand red for artist chart text and show genres

### DIFF
--- a/components/ArtistShareChart.jsx
+++ b/components/ArtistShareChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function ArtistShareChart({ tracks = [] }) {
+export default function ArtistShareChart({ tracks = [], artists = [] }) {
   const counts = {};
   tracks.forEach((t) => {
     (t.artists || []).forEach((a) => {
@@ -24,8 +24,13 @@ export default function ArtistShareChart({ tracks = [] }) {
     .map((s) => `${s.color} ${s.startAngle}deg ${s.endAngle}deg`)
     .join(", ");
 
+  const artistMap = artists.reduce((map, a) => {
+    map[a.name] = a;
+    return map;
+  }, {});
+
   return (
-    <div style={{ width: 180, textAlign: "center", color: "#fff" }}>
+    <div style={{ width: 180, textAlign: "center", color: "#CB1F1F" }}>
       <div
         style={{
           width: 180,
@@ -36,12 +41,34 @@ export default function ArtistShareChart({ tracks = [] }) {
         }}
       />
       <ul style={{ listStyle: "none", padding: 0, margin: "8px 0 0" }}>
-        {segments.map((s) => (
-          <li key={s.name} style={{ fontSize: 12, marginBottom: 4, display: "flex", alignItems: "center", justifyContent: "center" }}>
-            <span style={{ width: 12, height: 12, backgroundColor: s.color, borderRadius: "50%", display: "inline-block", marginRight: 4 }} />
-            {s.name} ({Math.round(s.share * 100)}%)
-          </li>
-        ))}
+        {segments.map((s) => {
+          const genres = artistMap[s.name]?.genres?.join(", ");
+          return (
+            <li
+              key={s.name}
+              style={{
+                fontSize: 12,
+                marginBottom: 4,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <span
+                style={{
+                  width: 12,
+                  height: 12,
+                  backgroundColor: s.color,
+                  borderRadius: "50%",
+                  display: "inline-block",
+                  marginRight: 4,
+                }}
+              />
+              {s.name}
+              {genres ? ` – ${genres}` : ""} ({Math.round(s.share * 100)}%)
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -95,10 +95,10 @@ export default function Card({ personality, tracks = [], artists = [], overrides
               justifyContent: "center",
               gap: 16,
               padding: "24px 0",
-              color: "#fff",
+              color: "#CB1F1F",
             }}
           >
-            <ArtistShareChart tracks={tracks} />
+            <ArtistShareChart tracks={tracks} artists={artists} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update artist share chart text color to brand red
- apply matching color overlay on card back
- display each artist's genres alongside their share

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8f0c857a08332a767b9e305b491e0