### PR TITLE
Add genre cloud chart to card back

### DIFF
--- a/components/Card.jsx
+++ b/components/Card.jsx
@@ -3,6 +3,7 @@ import { toPng } from "html-to-image";
 import { saveAs } from "file-saver";
 import { frontPathFor, backPathFor } from "../utils/assets";
 import ArtistShareChart from "./ArtistShareChart";
+import GenreCloudChart from "./GenreCloudChart";
 
 export default function Card({ personality, tracks = [], artists = [], overrides = {} }) {
   // reference each card face for PNG export
@@ -99,6 +100,7 @@ export default function Card({ personality, tracks = [], artists = [], overrides
             }}
           >
             <ArtistShareChart tracks={tracks} artists={artists} />
+            <GenreCloudChart artists={artists} />
           </div>
         </div>
       </div>

--- a/components/GenreCloudChart.jsx
+++ b/components/GenreCloudChart.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+export default function GenreCloudChart({ artists = [] }) {
+  const counts = {};
+  artists.forEach((a) => {
+    (a.genres || []).forEach((g) => {
+      counts[g] = (counts[g] || 0) + 1;
+    });
+  });
+  const entries = Object.entries(counts);
+  if (entries.length === 0) return null;
+
+  const max = Math.max(...entries.map(([, c]) => c));
+
+  return (
+    <div style={{ width: 260, textAlign: "center", color: "#CB1F1F" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 4,
+          marginBottom: 8,
+        }}
+      >
+        <span style={{ fontWeight: 700 }}>Genre Cloud</span>
+        <span
+          style={{ cursor: "help" }}
+          title="Shows which genres appear most in your top artists—bigger = more frequent."
+        >
+          ℹ️
+        </span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "center",
+          gap: 8,
+        }}
+      >
+        {entries
+          .sort((a, b) => b[1] - a[1])
+          .map(([genre, count]) => {
+            const size = 12 + (count / max) * 24;
+            return (
+              <span key={genre} style={{ fontSize: size }}>
+                {genre}
+              </span>
+            );
+          })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add GenreCloudChart component to visualize dominant genres from top artists
- show GenreCloudChart below ArtistShareChart on card back

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8fa6bf8a483329b36f25b0440984f