### PR TITLE
Add favicon links to application

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,31 @@
 import '../styles/globals.css';
+import Head from 'next/head';
 
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/favicon_io/apple-touch-icon.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/favicon_io/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/favicon_io/favicon-16x16.png"
+        />
+        <link rel="icon" href="/favicon_io/favicon.ico" />
+        <link rel="manifest" href="/favicon_io/site.webmanifest" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }

--- a/public/favicon_io/site.webmanifest
+++ b/public/favicon_io/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"/favicon_io/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/favicon_io/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
## Summary
- add favicon and manifest links in `_app.jsx`
- update web manifest icon paths

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b902da68f483328a87d57ea579e424