### PR TITLE
Generate Spotify redirect URI dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Steps:
 
 2. Copy at least one back PNG into `public/cards/backs/back.png` (or per-personality: `the-ace-back.png`, ...)
 
-3. Create `.env.local` from `.env.example` and add your `SPOTIFY_CLIENT_SECRET`.
+3. Create a `.env.local` file with your Spotify credentials:
+   ```
+   NEXT_PUBLIC_SPOTIFY_CLIENT_ID=<your-client-id>
+   SPOTIFY_CLIENT_ID=<your-client-id>
+   SPOTIFY_CLIENT_SECRET=<your-client-secret>
+   ```
 
 4. Install & run:
    ```

--- a/pages/api/spotify/callback.js
+++ b/pages/api/spotify/callback.js
@@ -4,10 +4,14 @@ export default async function handler(req, res) {
   const code = req.query.code;
   if (!code) return res.status(400).send("Missing code");
 
+  const protocol = req.headers["x-forwarded-proto"] || "http";
+  const host = req.headers["x-forwarded-host"] || req.headers.host;
+  const redirectUri = `${protocol}://${host}/api/spotify/callback`;
+
   const params = new URLSearchParams({
     grant_type: "authorization_code",
     code,
-    redirect_uri: process.env.NEXT_PUBLIC_REDIRECT_URI,
+    redirect_uri: redirectUri,
   }).toString();
 
   try {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,12 +4,17 @@ import Link from "next/link";
 
 const SCOPES = ["user-top-read"].join(" ");
 const CLIENT_ID = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
-const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
 
 export default function Home() {
-  const authUrl = `https://accounts.spotify.com/authorize?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(
-    REDIRECT_URI
-  )}&scope=${encodeURIComponent(SCOPES)}`;
+  const [authUrl, setAuthUrl] = React.useState("");
+
+  React.useEffect(() => {
+    const redirectUri = `${window.location.origin}/api/spotify/callback`;
+    const url = `https://accounts.spotify.com/authorize?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(
+      redirectUri
+    )}&scope=${encodeURIComponent(SCOPES)}`;
+    setAuthUrl(url);
+  }, []);
 
   return (
     <main className="main-container">
@@ -22,9 +27,11 @@ export default function Home() {
       </p>
 
       <div className="auth-box" aria-hidden={false}>
-        <a className="auth-btn" href={authUrl} role="button">
-          Login with Spotify
-        </a>
+        {authUrl && (
+          <a className="auth-btn" href={authUrl} role="button">
+            Login with Spotify
+          </a>
+        )}
       </div>
       <nav className="page-links">
         <Link href="/privacy">Data Privacy</Link> | <Link href="/kontakt">Contact</Link>


### PR DESCRIPTION
## Summary
- compute Spotify authorization URL on the client using the current origin
- derive redirect URI on the callback API route from request headers
- document required Spotify environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SPOTIFY_CLIENT_ID=foo SPOTIFY_CLIENT_ID=foo SPOTIFY_CLIENT_SECRET=bar npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b94c50ff988332bcf66d1e65000bb5