### PR TITLE
Revert dynamic Spotify redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,7 @@ Steps:
 
 2. Copy at least one back PNG into `public/cards/backs/back.png` (or per-personality: `the-ace-back.png`, ...)
 
-3. Create a `.env.local` file with your Spotify credentials:
-   ```
-   NEXT_PUBLIC_SPOTIFY_CLIENT_ID=<your-client-id>
-   SPOTIFY_CLIENT_ID=<your-client-id>
-   SPOTIFY_CLIENT_SECRET=<your-client-secret>
-   ```
+3. Create `.env.local` from `.env.example` and add your `SPOTIFY_CLIENT_SECRET`.
 
 4. Install & run:
    ```

--- a/pages/api/spotify/callback.js
+++ b/pages/api/spotify/callback.js
@@ -4,14 +4,10 @@ export default async function handler(req, res) {
   const code = req.query.code;
   if (!code) return res.status(400).send("Missing code");
 
-  const protocol = req.headers["x-forwarded-proto"] || "http";
-  const host = req.headers["x-forwarded-host"] || req.headers.host;
-  const redirectUri = `${protocol}://${host}/api/spotify/callback`;
-
   const params = new URLSearchParams({
     grant_type: "authorization_code",
     code,
-    redirect_uri: redirectUri,
+    redirect_uri: process.env.NEXT_PUBLIC_REDIRECT_URI,
   }).toString();
 
   try {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,17 +4,12 @@ import Link from "next/link";
 
 const SCOPES = ["user-top-read"].join(" ");
 const CLIENT_ID = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
+const REDIRECT_URI = process.env.NEXT_PUBLIC_REDIRECT_URI;
 
 export default function Home() {
-  const [authUrl, setAuthUrl] = React.useState("");
-
-  React.useEffect(() => {
-    const redirectUri = `${window.location.origin}/api/spotify/callback`;
-    const url = `https://accounts.spotify.com/authorize?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(
-      redirectUri
-    )}&scope=${encodeURIComponent(SCOPES)}`;
-    setAuthUrl(url);
-  }, []);
+  const authUrl = `https://accounts.spotify.com/authorize?client_id=${CLIENT_ID}&response_type=code&redirect_uri=${encodeURIComponent(
+    REDIRECT_URI
+  )}&scope=${encodeURIComponent(SCOPES)}`;
 
   return (
     <main className="main-container">
@@ -27,11 +22,9 @@ export default function Home() {
       </p>
 
       <div className="auth-box" aria-hidden={false}>
-        {authUrl && (
-          <a className="auth-btn" href={authUrl} role="button">
-            Login with Spotify
-          </a>
-        )}
+        <a className="auth-btn" href={authUrl} role="button">
+          Login with Spotify
+        </a>
       </div>
       <nav className="page-links">
         <Link href="/privacy">Data Privacy</Link> | <Link href="/kontakt">Contact</Link>


### PR DESCRIPTION
## Summary
- Revert merge of PR #27 to undo dynamic Spotify redirect logic
- Restore environment-based redirect handling in login and callback pages
- Update README to reference `.env.example` instead of explicit credentials list

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b94dbd08688332929f74af1eb8a233